### PR TITLE
Transform Synthesizer Data for the View

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,34 +298,39 @@ class ShowArticles extends Component
 }
 ```
 
-### EXPERIMENTAL: Statamic Support
-As a little experiment, support for an Entry or EntryCollection has been added, so you can make an entry or a entry collection simply a public property and it just works.
-
-Supported types:
-- Statamic\Entries\EntryCollection;
-- Statamic\Entries\Entry;
+### Synthesizers (experimental)
+You can use the built-in Synthesizers to make your Livewire components aware of Statamic specific data types.
 
 ```php
-namespace App\Livewire;
-
-use Livewire\Component;
 use Statamic\Entries\EntryCollection;
 use Statamic\Entries\Entry;
 
 class Foo extends Component
 {
     public EntryCollection $entries;
-    public Entry $entry;
 
-    // normal livewire stuff
+    public function mount(){
+        $this->entries = \Statamic\Facades\Entry::all();
+    }
 }
 ```
 
+
+Currently, the following types are supported:
+- `Statamic\Entries\EntryCollection`;
+- `Statamic\Entries\Entry`;
+- `Statamic\Fields\Field`;
+- `Statamic\Fields\Fieldtype`;
+- `Statamic\Fields\Value`;
+
 To make it work, you need to enable that feature first.
 
-1. php artisan vendor:publish
-2. Select statamic-livewire in the list
+1. Run `php artisan vendor:publish`
+2. Select `statamic-livewire` in the list
 3. Enable synthesizers
+
+#### Transformation
+By default, the Synthesizers transform (augment) the data before it gets passed into the view. You can disable this by setting `synthesizers.transform` to `false` in your published `config/statamic-livewire.php` config.
 
 ### Entangle: Sharing State Between Livewire And Alpine
 In case you want to share state between Livewire and Alpine, there is a Blade directive called `@entangle`. To be usable with Antlers, we do provide a dedicated tag:

--- a/config/statamic-livewire.php
+++ b/config/statamic-livewire.php
@@ -52,6 +52,8 @@ return [
             \MarcoRieser\Livewire\Synthesizers\FieldtypeSynthesizer::class,
             \MarcoRieser\Livewire\Synthesizers\ValueSynthesizer::class,
         ],
+
+        'transform' => true,
     ],
 
     /*

--- a/config/statamic-livewire.php
+++ b/config/statamic-livewire.php
@@ -8,10 +8,10 @@ return [
     |--------------------------------------------------------------------------
     |
     | When enabled, the Localize Middleware from Statamic gets applied to
-    | Livewire requests and the configured locales per site are handled
+    | Livewire requests, and the configured locales per site are handled
     | automatically. This makes the `RestoreCurrentSite` obsolete.
     |
-    | This features is experimental. It's meant to be tested and to played
+    | This feature is experimental. It's meant to be tested and to be played
     | with. As long as it is experimental, it can be changed and removed
     | at any point without a warning.
     |
@@ -28,14 +28,14 @@ return [
     | EXPERIMENTAL: Livewire Synthesizers
     |--------------------------------------------------------------------------
     |
-    | So called synthesizers allow to add custom types to Livewire, which can
+    | So called synthesizers allow adding custom types to Livewire, which can
     | can be used to make Livewire aware of Statamic classes that you want
     | to work with, as it might make things easier.
     |
     | It's recommended to remove or uncomment those synthesizers that are
-    | not used in your application, to avoid overhead by loading those.
+    | not used in your application to avoid overhead by loading those.
     |
-    | This features is experimental. It's meant to be tested and to played
+    | This feature is experimental. It's meant to be tested and to be played
     | with. As long as it is experimental, it can be changed and removed
     | at any point without a warning.
     |

--- a/src/Hooks/TransformSynthesizers.php
+++ b/src/Hooks/TransformSynthesizers.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace MarcoRieser\Livewire\Hooks;
+
+use Livewire\ComponentHook;
+
+class TransformSynthesizers extends ComponentHook
+{
+    public function render($view, $data): void
+    {
+        if (! config('statamic-livewire.synthesizers.enabled', false) || ! config('statamic-livewire.synthesizers.transform', true)) {
+            return;
+        }
+
+        collect($data)
+            ->map(function ($value) {
+                $synthesizer = collect(config('statamic-livewire.synthesizers.classes', []))
+                    ->filter(fn (string $synthesizer) => call_user_func([$synthesizer, 'match'], $value))
+                    ->first();
+
+                return $synthesizer ? call_user_func([$synthesizer, 'transform'], $value) : $value;
+            })
+            ->each(fn ($value, $key) => $view->with($key, $value));
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -5,6 +5,7 @@ namespace MarcoRieser\Livewire;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\Router;
 use Livewire\Livewire;
+use MarcoRieser\Livewire\Hooks\TransformSynthesizers;
 use MarcoRieser\Livewire\Http\Middleware\ResolveCurrentSiteByLivewireUrl;
 use Statamic\Http\Middleware\Localize;
 use Statamic\Providers\AddonServiceProvider;
@@ -14,6 +15,13 @@ class ServiceProvider extends AddonServiceProvider
     protected $tags = [
         'MarcoRieser\Livewire\Tags\Livewire',
     ];
+
+    public function register(): void
+    {
+        parent::register();
+
+        $this->registerSynthesizerTransformations();
+    }
 
     public function bootAddon(): void
     {
@@ -55,5 +63,10 @@ class ServiceProvider extends AddonServiceProvider
         foreach ($synthesizers as $synthesizer) {
             Livewire::propertySynthesizer($synthesizer);
         }
+    }
+
+    protected function registerSynthesizerTransformations(): void
+    {
+        Livewire::componentHook(TransformSynthesizers::class);
     }
 }

--- a/src/Synthesizers/AbstractSynthesizer.php
+++ b/src/Synthesizers/AbstractSynthesizer.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace MarcoRieser\Livewire\Synthesizers;
+
+use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
+
+abstract class AbstractSynthesizer extends Synth
+{
+    abstract public static function transform($target): mixed;
+}

--- a/src/Synthesizers/EntryCollectionSynthesizer.php
+++ b/src/Synthesizers/EntryCollectionSynthesizer.php
@@ -4,11 +4,10 @@ namespace MarcoRieser\Livewire\Synthesizers;
 
 use Carbon\CarbonInterface;
 use Illuminate\Support\Carbon;
-use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 use Statamic\Entries\EntryCollection as StatamicEntryCollection;
 use Statamic\Facades\Entry;
 
-class EntryCollectionSynthesizer extends Synth
+class EntryCollectionSynthesizer extends AbstractSynthesizer
 {
     public static string $key = 'statamic-entry-collection';
 
@@ -59,5 +58,10 @@ class EntryCollectionSynthesizer extends Synth
         }
 
         return new StatamicEntryCollection($items);
+    }
+
+    public static function transform($target): mixed
+    {
+        return $target->toAugmentedArray();
     }
 }

--- a/src/Synthesizers/EntrySynthesizer.php
+++ b/src/Synthesizers/EntrySynthesizer.php
@@ -4,11 +4,10 @@ namespace MarcoRieser\Livewire\Synthesizers;
 
 use Carbon\CarbonInterface;
 use Illuminate\Support\Carbon;
-use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 use Statamic\Contracts\Entries\Entry;
 use Statamic\Facades\Entry as EntryFacade;
 
-class EntrySynthesizer extends Synth
+class EntrySynthesizer extends AbstractSynthesizer
 {
     public static string $key = 'statamic-entry';
 
@@ -48,5 +47,10 @@ class EntrySynthesizer extends Synth
         }
 
         return $entry;
+    }
+
+    public static function transform($target): mixed
+    {
+        return $target->toAugmentedArray();
     }
 }

--- a/src/Synthesizers/FieldSynthesizer.php
+++ b/src/Synthesizers/FieldSynthesizer.php
@@ -2,10 +2,9 @@
 
 namespace MarcoRieser\Livewire\Synthesizers;
 
-use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 use Statamic\Fields\Field;
 
-class FieldSynthesizer extends Synth
+class FieldSynthesizer extends AbstractSynthesizer
 {
     public static string $key = 'statamic-field';
 
@@ -35,5 +34,10 @@ class FieldSynthesizer extends Synth
         }
 
         return new Field(...$value);
+    }
+
+    public static function transform($target): mixed
+    {
+        return $target->augment();
     }
 }

--- a/src/Synthesizers/FieldtypeSynthesizer.php
+++ b/src/Synthesizers/FieldtypeSynthesizer.php
@@ -2,10 +2,9 @@
 
 namespace MarcoRieser\Livewire\Synthesizers;
 
-use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 use Statamic\Fields\Fieldtype;
 
-class FieldtypeSynthesizer extends Synth
+class FieldtypeSynthesizer extends AbstractSynthesizer
 {
     public static string $key = 'statamic-fieldtype';
 
@@ -37,5 +36,10 @@ class FieldtypeSynthesizer extends Synth
         }
 
         return app($meta['class'])->setField($value['field']);
+    }
+
+    public static function transform($target): mixed
+    {
+        return $target;
     }
 }

--- a/src/Synthesizers/ValueSynthesizer.php
+++ b/src/Synthesizers/ValueSynthesizer.php
@@ -2,12 +2,11 @@
 
 namespace MarcoRieser\Livewire\Synthesizers;
 
-use Livewire\Mechanisms\HandleComponents\Synthesizers\Synth;
 use Statamic\Fields\Value;
 
 use function Livewire\invade;
 
-class ValueSynthesizer extends Synth
+class ValueSynthesizer extends AbstractSynthesizer
 {
     public static string $key = 'statamic-value';
 
@@ -42,5 +41,10 @@ class ValueSynthesizer extends Synth
         }
 
         return new Value(...$value);
+    }
+
+    public static function transform($target): mixed
+    {
+        return $target;
     }
 }


### PR DESCRIPTION
This PR allows Synthesizers to transform their data before passing it into the view. This means, e.g., `public EntryCollection $entries` gets augmented automatically like it would be when using Statamics Collection Tag.

Closes: #3 