### PR TITLE
Require PHP `^8.2` and Statamic `^5.17.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,9 +29,8 @@
         "docs": "https://github.com/marcorieser/statamic-livewire"
     },
     "require": {
-        "php": "^8.1",
-        "illuminate/support": "^10.0|^11.0|^12.0",
-        "statamic/cms": "^4.23.2|^5.0",
+        "php": "^8.2",
+        "statamic/cms": "^5.17.0",
         "livewire/livewire": "^3.0"
     },
     "extra": {


### PR DESCRIPTION
- Updated PHP requirement to `^8.2` and Statamic CMS to `^5.17.0`. 
- Removed direct dependency on `illuminate/support`.

Fixes: https://github.com/marcorieser/statamic-livewire/security/dependabot/1