### PR TITLE
Prevent parameters from being converted to an array

### DIFF
--- a/src/Tags/Livewire.php
+++ b/src/Tags/Livewire.php
@@ -43,7 +43,7 @@ class Livewire extends Tags
             return null;
         }
 
-        return \Livewire\Livewire::mount($component, $this->params->except('key')->toArray(), $this->params->only('key')->first());
+        return \Livewire\Livewire::mount($component, $this->params->except('key')->all(), $this->params->only('key')->first());
     }
 
     /**

--- a/tests/Tags/LivewireTest.php
+++ b/tests/Tags/LivewireTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace MarcoRieser\Livewire\Tests\Hooks;
+
+use Livewire\Component;
+use Livewire\Livewire;
+use MarcoRieser\Livewire\Tests\TestCase;
+use MarcoRieser\Livewire\Tests\Traits\ManipulateAddonConfig;
+use Orchestra\Testbench\Attributes\DefineEnvironment;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Collection;
+use Statamic\Facades\Entry;
+use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
+
+class LivewireTest extends TestCase
+{
+    use ManipulateAddonConfig;
+    use PreventsSavingStacheItemsToDisk;
+
+    #[Test]
+    #[DefineEnvironment('enableSynthesizers')]
+    public function parameters_keep_their_type_when_passed_to_a_component()
+    {
+        $component = new class extends Component
+        {
+            public \Statamic\Contracts\Entries\Entry $entry;
+
+            public function render()
+            {
+                return '<div></div>';
+            }
+        };
+
+        $entry = Entry::find('1');
+
+        $testable = Livewire::test($component, ['entry' => $entry]);
+
+        $testable->assertSetStrict('entry', $entry);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Collection::make('entries')->save();
+
+        Entry::make()
+            ->collection('entries')
+            ->id('1')
+            ->data(['title' => 'Entry 1'])
+            ->save();
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,7 +2,6 @@
 
 namespace MarcoRieser\Livewire\Tests;
 
-use Illuminate\Support\Arr;
 use Livewire\LivewireServiceProvider;
 use MarcoRieser\Livewire\ServiceProvider;
 use Spatie\LaravelRay\RayServiceProvider;
@@ -23,15 +22,6 @@ abstract class TestCase extends AddonTestCase
             ],
             parent::getPackageProviders($app)
         );
-    }
-
-    protected function setConfigValue(string $key, $value): void
-    {
-        $config = config()->array('statamic-livewire', require __DIR__.'/../config/statamic-livewire.php');
-
-        Arr::set($config, $key, $value);
-
-        config()->set('statamic-livewire', $config);
     }
 
     protected function setUp(): void

--- a/tests/Traits/ManipulateAddonConfig.php
+++ b/tests/Traits/ManipulateAddonConfig.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace MarcoRieser\Livewire\Tests\Traits;
+
+use Illuminate\Support\Arr;
+
+trait ManipulateAddonConfig
+{
+    protected function enableSynthesizers(): void
+    {
+        $this->setConfigValue('synthesizers.enabled', true);
+    }
+
+    protected function disableSynthesizers(): void
+    {
+        $this->setConfigValue('synthesizers.enabled', false);
+    }
+
+    protected function disableSynthesizerTransform(): void
+    {
+        $this->setConfigValue('synthesizers.transform', false);
+    }
+
+    protected function enableSynthesizerTransform(): void
+    {
+        $this->setConfigValue('synthesizers.transform', true);
+    }
+
+    protected function setConfigValue(string $key, $value): void
+    {
+        $config = config()->array('statamic-livewire', require __DIR__.'/../../config/statamic-livewire.php');
+
+        Arr::set($config, $key, $value);
+
+        config()->set('statamic-livewire', $config);
+    }
+}


### PR DESCRIPTION
Fixes #7 