### PR TITLE
[6.x] match blade's island scope limitation instead of exceeding it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Full rewrite targeting Livewire 4 and Statamic 6 exclusively. See the [upgrade g
 ### Added
 
 - Slots for Antlers views, including named slots (`{{ livewire:slot }}`)
-- Islands for Antlers views (`{{ livewire:island }}`) with lazy, defer, always and skip modes, placeholders (`{{ livewire:placeholder }}`), captured scope, and loops via dynamic names
+- Islands for Antlers views (`{{ livewire:island }}`) with lazy, defer, always and skip modes, placeholders (`{{ livewire:placeholder }}`), and loops via dynamic names
 - Lazy and deferred component loading through the mount tag (`lazy="true"` / `defer="true"`)
 - `{{ livewire:assets }}` works outside of component views
 - Back/forward-cache protection headers are restored on statically cached pages ([#30](https://github.com/marcorieser/statamic-livewire/issues/30))

--- a/README.md
+++ b/README.md
@@ -306,17 +306,17 @@ Islands can be [loaded lazily](https://livewire.laravel.com/docs/islands#lazy-lo
 {{ /livewire:island }}
 ```
 
-Islands can be nested, and island content sees the component's scope (its public and computed properties). To bring additional variables into an island — for example loop values — pass them as parameters. Their values are captured when the island is defined and persist across island updates:
+Islands can be nested, and island content sees the component's scope (its public and computed properties) — not the surrounding template's, so loop values aren't available inside an island's own content, same as Blade's `@island`. In a loop, give each island a dynamic `name` (resolved where the tag is parsed, so this part does see the loop):
 
 ```antlers
 {{ items }}
-    {{ livewire:island name="item-{id}" :item="id" }}
-        <span>{{ item }}</span>
+    {{ livewire:island name="item-{id}" }}
+        <span>{{ count }}</span>
     {{ /livewire:island }}
 {{ /items }}
 ```
 
-Every island needs a `name` that is unique within its component — in loops, make it dynamic like above. Captured values are stored in the component's payload, so keep them small and JSON-serializable (ids, not entries).
+Every island needs a `name` that is unique within its component — in loops, make it dynamic like above.
 
 ### Pagination
 

--- a/src/Islands/IslandManager.php
+++ b/src/Islands/IslandManager.php
@@ -73,8 +73,7 @@ class IslandManager
 
         $isPlaceholder = array_key_exists('__placeholder', $scope);
 
-        // Runtime island data from renderIsland()/streamIsland() overrides
-        // the scope captured by the island tag.
+        // Runtime island data from renderIsland()/streamIsland().
         $runtimeWith = $scope['__runtimeWith'] ?? [];
         $runtimeWith = is_array($runtimeWith) ? $runtimeWith : [];
 
@@ -89,7 +88,7 @@ class IslandManager
             $scope['slots'] = $slots;
         }
 
-        $scope = [...$scope, ...$this->islandScope($token, $component), ...$runtimeWith];
+        $scope = [...$scope, ...$runtimeWith];
 
         [$content, $placeholder] = $this->splitPlaceholder($source);
 
@@ -169,28 +168,6 @@ class IslandManager
         }
 
         return [$source, $placeholder];
-    }
-
-    /**
-     * The island's persisted scope values, captured by the island tag.
-     *
-     * @return array<mixed>
-     */
-    protected function islandScope(string $token, mixed $component): array
-    {
-        if (! $component instanceof Component) {
-            return [];
-        }
-
-        foreach ($component->getIslands() as $island) {
-            if (($island['token'] ?? null) === $token) {
-                $with = $island['with'] ?? [];
-
-                return is_array($with) ? $with : [];
-            }
-        }
-
-        return [];
     }
 
     protected function sourcePath(string $token): string

--- a/src/Tags/Livewire.php
+++ b/src/Tags/Livewire.php
@@ -113,15 +113,7 @@ class Livewire extends Tags
 
         $manager->store($token, (string) $this->content);
 
-        // Any other parameters become the island's scope. Unlike Blade's
-        // with:, the values are captured here — with the surrounding template
-        // context available — and persisted through the component memo, so
-        // island updates can re-render with them.
-        $with = $this->params->except(['name', 'lazy', 'defer', 'always', 'skip'])->toArray();
-
-        $this->registerIsland($component, $name, $token, $with);
-
-        $html = $component->renderIslandDirective(
+        return $component->renderIslandDirective(
             name: $name,
             token: $token,
             lazy: $this->boolParam('lazy'),
@@ -129,28 +121,6 @@ class Livewire extends Tags
             always: $this->boolParam('always'),
             skip: $this->boolParam('skip'),
         );
-
-        // renderIslandDirective() registers the island again while mounting —
-        // drop that duplicate in favor of the entry carrying the scope.
-        $this->registerIsland($component, $name, $token, $with);
-
-        return $html;
-    }
-
-    /**
-     * @param  array<mixed>  $with
-     */
-    protected function registerIsland(Component $component, string $name, string $token, array $with): void
-    {
-        $component->setIslands(collect($component->getIslands())
-            ->reject(fn (array $island): bool => ($island['name'] ?? null) === $name)
-            ->values()
-            ->push(array_filter([
-                'name' => $name,
-                'token' => $token,
-                'with' => $with,
-            ], fn (mixed $value): bool => $value !== []))
-            ->all());
     }
 
     /**

--- a/tests/Feature/IslandsTest.php
+++ b/tests/Feature/IslandsTest.php
@@ -207,32 +207,19 @@ it('renders nested islands', function (): void {
         ->toContain('&quot;name&quot;:&quot;inner&quot;');
 });
 
-it('persists captured island scope across island updates', function (): void {
-    $html = mountIslands('island-counter-with');
-
-    expect($html)->toContain('live: 0 captured: 0');
-
-    $response = postLivewireUpdate($this, $html, [
-        'method' => 'increment',
-        'params' => [],
-        'metadata' => ['island' => ['name' => 'stats', 'mode' => 'morph']],
-    ]);
-
-    $response->assertOk();
-
-    // The live property changed while the captured value stays as it was
-    // when the island was defined.
-    expect($response->content())->toContain('live: 1 captured: 0');
-});
-
-it('supports islands in loops via dynamic names and captured scope', function (): void {
+it('supports islands in loops via dynamic names, without capturing the loop scope', function (): void {
     $html = mountIslands('island-counter-loop');
 
+    // Dynamic names resolve fine — they're just a tag param, resolved where
+    // the tag is parsed. The loop's `value` isn't part of the island's own
+    // render scope though (same ceiling as Blade's `@island`): only the
+    // component's own properties (`count`) reach island content.
     expect($html)
-        ->toContain('island-1')
-        ->toContain('island-2')
         ->toContain('&quot;name&quot;:&quot;item-1&quot;')
-        ->toContain('&quot;name&quot;:&quot;item-2&quot;');
+        ->toContain('&quot;name&quot;:&quot;item-2&quot;')
+        ->toContain('count-0')
+        ->not->toContain('island-1')
+        ->not->toContain('island-2');
 
     $response = postLivewireUpdate($this, $html, [
         'method' => '$refresh',
@@ -242,9 +229,7 @@ it('supports islands in loops via dynamic names and captured scope', function ()
 
     $response->assertOk();
 
-    expect($response->content())
-        ->toContain('island-2')
-        ->not->toContain('island-1');
+    expect($response->content())->toContain('count-0');
 });
 
 it('throws when the island tag is used outside a component view', function (): void {

--- a/tests/Fixtures/views/island-counter-loop.antlers.html
+++ b/tests/Fixtures/views/island-counter-loop.antlers.html
@@ -1,7 +1,7 @@
 <div>
     {{ items }}
-        {{ livewire:island name="item-{value}" :item="value" }}
-            <span>island-{{ item }}</span>
+        {{ livewire:island name="item-{value}" }}
+            <span>island-{{ value }} count-{{ count }}</span>
         {{ /livewire:island }}
     {{ /items }}
 </div>

--- a/tests/Fixtures/views/island-counter-with.antlers.html
+++ b/tests/Fixtures/views/island-counter-with.antlers.html
@@ -1,5 +1,0 @@
-<div>
-    {{ livewire:island name="stats" :captured="count" }}
-        <span>live: {{ count }} captured: {{ captured }}</span>
-    {{ /livewire:island }}
-</div>


### PR DESCRIPTION
## Summary
- `{{ livewire:island }}` captured extra tag params (e.g. `:item="value"` in a loop) and persisted the resolved values through the component memo, so island updates could re-render with them — something Blade's native `@island` can't do (its `with:` expression re-evaluates in the island's own isolated compiled file, with no access to the enclosing loop variable, so it throws `Undefined variable`).
- That inconsistency between engines is more surprising than useful: island content now only sees the component's own scope (public and computed properties) in both Antlers and Blade, matching Blade's ceiling.
- Dynamic island names in loops (`name="item-{id}"`) still work — name resolution happens where the tag is parsed, unaffected by this.
- The capability itself was correct and tested; it's intentionally being dropped here so it can be reintroduced in a follow-up PR as a deliberate improvement over Blade, not a silent inconsistency.

## Test plan
- [x] `composer test` green (analyse, lint, refactor, type coverage, unit — 88/88, 100% coverage)
- [x] Rewrote the loop island test to assert the new ceiling (dynamic names still resolve, loop-local values don't reach island content)
- [x] Removed the captured-scope test + fixture (no longer a supported capability)
- [x] Updated README islands section and CHANGELOG