### PR TITLE
[6.x] rehydrate cascade when order-dependent on livewire update requests

### DIFF
--- a/src/Attributes/Cascade.php
+++ b/src/Attributes/Cascade.php
@@ -27,7 +27,11 @@ class Cascade extends LivewireAttribute
      */
     public function getCascadeData(): array
     {
-        if (($data = CascadeFacade::toArray()) === []) {
+        $data = CascadeFacade::toArray();
+
+        // hydration only sets 'current_url', unlike `views`, which Antlers
+        // writes as a side effect of rendering any view.
+        if (! Arr::has($data, 'current_url')) {
             $data = CascadeFacade::hydrate()->toArray();
         }
 

--- a/tests/Feature/CascadeTest.php
+++ b/tests/Feature/CascadeTest.php
@@ -53,6 +53,27 @@ it('throws for a selected cascade key that does not exist', function (): void {
     antlers('{{ livewire:missing-cascade-key-viewer }}');
 })->throws(CascadeDataNotFoundException::class);
 
+it('resolves cascade keys even when another component rendered antlers first in the same request', function (): void {
+    seedUnhydratedCascadeViewsKey();
+
+    expect(antlers('{{ livewire:selective-cascade-viewer }}'))
+        ->toContain('url: http://localhost')
+        ->toContain('fallback: fallback-value');
+});
+
+it('resolves the whole cascade even when another component rendered antlers first in the same request', function (): void {
+    seedUnhydratedCascadeViewsKey();
+
+    expect(antlers('{{ livewire:cascade-viewer }}'))->toContain('url: http://localhost');
+});
+
+it('prefers the real cascade value over a key default when another component rendered antlers first in the same request', function (): void {
+    seedUnhydratedCascadeViewsKey();
+
+    expect(new Cascade(['current_url' => 'fallback-value'])->getCascadeData())
+        ->toBe(['current_url' => 'http://localhost']);
+});
+
 it('lets computed properties win over cascade data', function (): void {
     Livewire::component('cascade-computed-viewer', CascadeComputedViewer::class);
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -7,6 +7,7 @@ use Illuminate\Testing\TestResponse;
 use Livewire\Livewire;
 use MarcoRieser\Livewire\ServiceProvider;
 use MarcoRieser\Livewire\Tests\TestCase;
+use Statamic\Facades\Cascade;
 use Statamic\Facades\Parse;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -32,6 +33,16 @@ function addonProvider(): ServiceProvider
 function antlers(string $template, array $context = []): string
 {
     return (string) Parse::template($template, $context, [], true);
+}
+
+/**
+ * Seed the cascade the way Statamic's Antlers\Engine::get() does as a side
+ * effect of rendering any view, without actually hydrating it. Simulates
+ * another component having rendered Antlers first in the same request.
+ */
+function seedUnhydratedCascadeViewsKey(): void
+{
+    Cascade::set('views', []);
 }
 
 /**


### PR DESCRIPTION
## Summary

`#[Cascade]` threw `CascadeDataNotFoundException` on a `livewire.update` request whenever another component rendered Antlers first in the same request.

`Cascade::getCascadeData()` checked `toArray() === []` to decide whether to hydrate, but Antlers writes a `views` key into the cascade as a side effect of rendering any view. On an update request with multiple components, once one renders Antlers first, the cascade looks non-empty but was never actually hydrated — so `#[Cascade]` throws for every component processed after it.

Now checks for `current_url` instead, which is only ever set by hydration itself, distinguishing "hydrated" from "has incidental leftover data" regardless of component order.

Refs #36 (not closing — a v5 backport PR will follow separately and close it there)

## Test plan

- [x] New regression tests cover: selective keys, whole-cascade mode, and a selected key with an explicit default, all with another component's Antlers render seeding `views` first
- [x] `composer test` (PHPStan, Pint, Rector, Pest) passes, 100% coverage maintained