### PR TITLE
[5.x] fix: rehydrate cascade when order-dependent on livewire update requests

### DIFF
--- a/src/Attributes/Cascade.php
+++ b/src/Attributes/Cascade.php
@@ -14,7 +14,11 @@ class Cascade extends LivewireAttribute
 
     public function getCascadeData(): array
     {
-        if (! $data = CascadeFacade::toArray()) {
+        $data = CascadeFacade::toArray();
+
+        // 'current_url' only set by hydration, unlike 'views', which Antlers
+        // writes as a side effect of rendering any view.
+        if (! array_key_exists('current_url', $data)) {
             $data = CascadeFacade::hydrate()->toArray();
         }
 

--- a/tests/Features/CascadeVariables/CascadeVariablesAutoloaderTest.php
+++ b/tests/Features/CascadeVariables/CascadeVariablesAutoloaderTest.php
@@ -8,6 +8,7 @@ use Livewire\Livewire;
 use MarcoRieser\Livewire\Attributes\Cascade;
 use MarcoRieser\Livewire\Tests\TestCase;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Cascade as CascadeFacade;
 use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
 
 class CascadeVariablesAutoloaderTest extends TestCase
@@ -57,6 +58,35 @@ class CascadeVariablesAutoloaderTest extends TestCase
         $component = $this->getInvalidLivewireComponent();
 
         Livewire::test($component);
+    }
+
+    #[Test]
+    public function cascade_variables_are_autoloaded_even_when_another_component_rendered_antlers_first_in_the_same_request()
+    {
+        // What Antlers\Engine::get() does as a side effect of rendering any
+        // view. A cascade holding only this key is not actually hydrated yet.
+        CascadeFacade::set('views', []);
+
+        $component = $this->getAntlersLivewireComponent();
+
+        $testable = Livewire::test($component);
+
+        $testable->assertViewHas('homepage', '/');
+        $testable->assertViewHas('environment', 'testing');
+    }
+
+    #[Test]
+    public function cascade_variables_are_autoloaded_selectively_even_when_another_component_rendered_antlers_first_in_the_same_request()
+    {
+        CascadeFacade::set('views', []);
+
+        $component = $this->getSelectedLivewireComponent();
+
+        $testable = Livewire::test($component);
+
+        $testable->assertViewHas('homepage', '/');
+        $testable->assertViewHas('my_global', true);
+        $testable->assertViewMissing('environment');
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

v5 backport of #37.

`#[Cascade]` threw `CascadeDataNotFoundException` on a `livewire.update` request whenever another component rendered Antlers first in the same request.

`Cascade::getCascadeData()` checked `toArray()` for emptiness to decide whether to hydrate, but Antlers writes a `views` key into the cascade as a side effect of rendering any view. On an update request with multiple components, once one renders Antlers first, the cascade looks non-empty but was never actually hydrated — so `#[Cascade]` throws for every component processed after it.

Now checks for `current_url` instead, which is only ever set by hydration itself, distinguishing "hydrated" from "has incidental leftover data" regardless of component order.

Fixes #36

## Test plan

- [x] New regression tests cover both whole-cascade and selective-key `#[Cascade]` usage, with another component's Antlers render seeding `views` first
- [x] `./vendor/bin/phpunit` passes (33 tests)
- [x] Pint clean on changed files