### PR TITLE
[6.x] fix: prevent duplicate livewire assets on cached nocache re-renders

### DIFF
--- a/src/Replacers/AssetsReplacer.php
+++ b/src/Replacers/AssetsReplacer.php
@@ -58,9 +58,28 @@ class AssetsReplacer implements Replacer
         );
     }
 
+    /**
+     * NoCacheReplacer can re-render a `{{ nocache }}` component live on a
+     * cache hit, flipping Livewire's render-tracking state even though its
+     * assets are already baked into the cached HTML.
+     */
     public function replaceInCachedResponse(Response $response): void
     {
-        //
+        $content = $response->getContent();
+
+        if ($content === false || $content === '') {
+            return;
+        }
+
+        $assets = resolve(FrontendAssets::class);
+
+        if (str_contains($content, 'data-module-url=')) {
+            $assets->hasRenderedScripts = true;
+        }
+
+        if (str_contains($content, '<!-- Livewire Styles -->')) {
+            $assets->hasRenderedStyles = true;
+        }
     }
 
     protected function shouldInjectLivewireAssets(): bool

--- a/tests/Feature/StaticCachingTest.php
+++ b/tests/Feature/StaticCachingTest.php
@@ -149,6 +149,40 @@ it('ignores empty responses', function (): void {
         ->and($response->headers->has('Pragma'))->toBeFalse();
 });
 
+it('marks livewire scripts as already rendered when a cache hit already contains them', function (): void {
+    $content = '<html><head></head><body>'
+        .'<script src="/livewire/livewire.min.js" data-module-url="/livewire" data-update-uri="/livewire/update"></script>'
+        .'</body></html>';
+
+    (new AssetsReplacer)->replaceInCachedResponse(new Response($content));
+
+    expect(resolve(FrontendAssets::class)->hasRenderedScripts)->toBeTrue()
+        ->and(FrontendAssets::scripts())->toBeEmpty();
+});
+
+it('marks livewire styles as already rendered when a cache hit already contains them', function (): void {
+    $content = '<html><head><!-- Livewire Styles --><style>[wire\:loading]{}</style></head><body></body></html>';
+
+    (new AssetsReplacer)->replaceInCachedResponse(new Response($content));
+
+    expect(resolve(FrontendAssets::class)->hasRenderedStyles)->toBeTrue()
+        ->and(FrontendAssets::styles())->toBeEmpty();
+});
+
+it('leaves the render flags untouched on cache hits without baked-in livewire assets', function (): void {
+    (new AssetsReplacer)->replaceInCachedResponse(new Response('<html><body><div wire:id="abc">component</div></body></html>'));
+
+    expect(resolve(FrontendAssets::class)->hasRenderedScripts)->toBeFalse()
+        ->and(resolve(FrontendAssets::class)->hasRenderedStyles)->toBeFalse();
+});
+
+it('ignores empty responses on cache hits', function (): void {
+    (new AssetsReplacer)->replaceInCachedResponse(new Response(''));
+
+    expect(resolve(FrontendAssets::class)->hasRenderedScripts)->toBeFalse()
+        ->and(resolve(FrontendAssets::class)->hasRenderedStyles)->toBeFalse();
+});
+
 it('has no effect on the counterpart replacer phases', function (): void {
     $content = '<html><body><div wire:id="abc">x</div></body></html>';
     $response = new Response($content);


### PR DESCRIPTION
## Summary

On a cache hit under Statamic's half-measure static caching, a `{{ nocache }}` region containing a Livewire component gets a second copy of Livewire's `<script>`/`<style>` tags injected on top of the copy already baked into the cached HTML.

`AssetsReplacer::prepareResponseToCache()` bakes Livewire's assets into the cached HTML on a MISS and resets `FrontendAssets::hasRenderedScripts/hasRenderedStyles` so the first visitor's response still gets them via Livewire's own asset injector. On a HIT, Statamic core's `NoCacheReplacer` re-renders `{{ nocache }}` regions live, which can dehydrate a Livewire component and flip Livewire's static `SupportAutoInjectedAssets::$hasRenderedAComponentThisRequest`. Livewire's own `RequestHandled` listener then injects the assets again, since `AssetsReplacer::replaceInCachedResponse()` was an empty no-op and never told it the tags were already there.

Now `replaceInCachedResponse()` detects the already-baked-in script/style markup in the cached content and marks `FrontendAssets` as rendered, so Livewire's injector skips them.

Refs #39 (not closing — a v5 backport PR will follow separately and close it there)

## Test plan

- [x] New regression tests cover: scripts already present, styles already present, no baked-in assets (flags untouched), empty response
- [x] `composer test` (PHPStan, Pint, Rector, Pest) passes, 100% coverage maintained