### PR TITLE
[5.x] ci: drop unsupported Laravel 11 lane, fix broken style-fix workflow

### DIFF
--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -19,19 +19,18 @@ jobs:
           ref: ${{ github.head_ref }}
           persist-credentials: true
 
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v47
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
         with:
-          files: |
-            **.php
+          php-version: 8.4
+          tools: composer:v2
+          coverage: none
 
-      - name: "laravel-pint"
-        uses: aglipanci/laravel-pint-action@v2
-        with:
-          preset: laravel
-          verboseMode: true
-          onlyDirty: true
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Fix code style
+        run: vendor/bin/pint -v
 
       - name: Commit linted files
         uses: stefanzweifel/git-auto-commit-action@v7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,14 +7,13 @@ on:
 jobs:
   php_tests:
     strategy:
+      fail-fast: false
       matrix:
         php: [8.2, 8.3, 8.4, 8.5]
-        laravel: [11.*, 12.*, 13.*]
+        laravel: [12.*, 13.*]
         livewire: [3.*, 4.*]
         os: [ubuntu-latest]
         exclude:
-          - laravel: 11.*
-            php: 8.5
           - laravel: 13.*
             php: 8.2
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A third-party [Laravel Livewire](https://laravel-livewire.com/) integration for 
 
 ## Requirements
 - PHP 8.2+
-- Laravel 11+
+- Laravel 12+
 - Statamic 5+
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "require": {
         "php": "^8.2",
-        "laravel/framework": "^11.0 || ^12.0 || ^13.0",
+        "laravel/framework": "^12.0 || ^13.0",
         "statamic/cms": "^5.73.0 || ^6.0",
         "livewire/livewire": "^3.6.4 || ^4.0"
     },
@@ -57,7 +57,7 @@
     },
     "require-dev": {
         "laravel/pint": "^1.21",
-        "orchestra/testbench": "^9.0 || ^10.0 || ^11.0",
+        "orchestra/testbench": "^10.0 || ^11.0",
         "phpunit/phpunit": "^10.5|^11.0|^12.0",
         "spatie/laravel-ray": "^1.0"
     },

--- a/config/statamic-livewire.php
+++ b/config/statamic-livewire.php
@@ -1,5 +1,12 @@
 <?php
 
+use MarcoRieser\Livewire\Replacers\AssetsReplacer;
+use MarcoRieser\Livewire\Synthesizers\EntryCollectionSynthesizer;
+use MarcoRieser\Livewire\Synthesizers\EntrySynthesizer;
+use MarcoRieser\Livewire\Synthesizers\FieldSynthesizer;
+use MarcoRieser\Livewire\Synthesizers\FieldtypeSynthesizer;
+use MarcoRieser\Livewire\Synthesizers\ValueSynthesizer;
+
 return [
 
     /*
@@ -31,11 +38,11 @@ return [
         'enabled' => false,
 
         'classes' => [
-            \MarcoRieser\Livewire\Synthesizers\EntryCollectionSynthesizer::class,
-            \MarcoRieser\Livewire\Synthesizers\EntrySynthesizer::class,
-            \MarcoRieser\Livewire\Synthesizers\FieldSynthesizer::class,
-            \MarcoRieser\Livewire\Synthesizers\FieldtypeSynthesizer::class,
-            \MarcoRieser\Livewire\Synthesizers\ValueSynthesizer::class,
+            EntryCollectionSynthesizer::class,
+            EntrySynthesizer::class,
+            FieldSynthesizer::class,
+            FieldtypeSynthesizer::class,
+            ValueSynthesizer::class,
         ],
 
         'augmentation' => true,
@@ -52,6 +59,6 @@ return [
     */
 
     'replacers' => [
-        \MarcoRieser\Livewire\Replacers\AssetsReplacer::class,
+        AssetsReplacer::class,
     ],
 ];

--- a/src/Replacers/AssetsReplacer.php
+++ b/src/Replacers/AssetsReplacer.php
@@ -41,7 +41,7 @@ class AssetsReplacer implements Replacer
             /**
              * Ensure Livewire injects its assets on the initial request.
              *
-             * @see \Livewire\Features\SupportAutoInjectedAssets\SupportAutoInjectedAssets
+             * @see SupportAutoInjectedAssets
              */
             app(FrontendAssets::class)->hasRenderedStyles = false;
             app(FrontendAssets::class)->hasRenderedScripts = false;


### PR DESCRIPTION
## Summary

CI on `main` was broken independently of #41 (verified failing on `main` HEAD before that PR existed). Two separate causes:

**1. Test Suite matrix**: `statamic/cms` v5.74.0 dropped Laravel 11 support (now requires `laravel/framework ^12.40 || ^13.0`), so every `Laravel 11.*` job fails to resolve dependencies before any test runs. The matrix strategy had no `fail-fast: false`, so that one real failure cancelled every other combination too, making it look like the whole matrix was broken.

  - Dropped the Laravel 11 lane from `composer.json` (`laravel/framework`, `orchestra/testbench`) and the test matrix, matching what current Statamic releases actually support
  - Added `fail-fast: false` so a genuine failure in one lane doesn't hide the results of the others
  - Updated the README requirement from "Laravel 11+" to "Laravel 12+"

**2. Fix Code Style workflow**: the Docker-based `aglipanci/laravel-pint-action` fails with `The [--dirty] option is only available when using Git` — git ownership isn't set up correctly inside that action's container. The `--dirty` flag (only fix files with uncommitted changes) would also always be a no-op right after a clean checkout anyway. Replaced it with a plain step running the project's own pinned `laravel/pint` directly.

## Test plan

- [x] `composer update` resolves cleanly with the new constraints (no conflicts)
- [x] `vendor/bin/phpunit` passes (31 tests)
- [x] `vendor/bin/pint -v` runs successfully against the checked-out tree, confirming the new style-fix step works